### PR TITLE
Fix link to metascraper rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ And you will get the parsed data in the following format:
 }
 ```
 
-> Note: Not all of this, or even more, data might be available depending on the `meta` tags the page has in its HTML. (see [`metascraper`](https://github.com/ianstormtaylor/metascraper/tree/master/lib/rules) for the full list of supported properties)
+> Note: Not all of this, or even more, data might be available depending on the `meta` tags the page has in its HTML. (see [`metascraper`](https://github.com/microlinkhq/metascraper/blob/master/README.md#rules) for the full list of supported properties)
 
 We infer the data from more places than just the open graph meta tags, we also support twitter meta tags and fallback to standard HTML tags like e.g. the `title` tag if no open graph data was specified. Results are cached in memory for 24 hours, which means calling this with the same URL repeatedly won't have a large impact on your server!
 


### PR DESCRIPTION
Just noticed this broken link while going through the README. 